### PR TITLE
Bound TYPE_FLOAT strategy to IEEE 754 single-precision range

### DIFF
--- a/hypothesis_protobuf/module_conversion.py
+++ b/hypothesis_protobuf/module_conversion.py
@@ -9,6 +9,7 @@ from hypothesis import strategies as st
 from google.protobuf.internal.well_known_types import FieldDescriptor
 
 
+SINGLEPRECISION = dict(max_value=(2 - 2 ** -23) * 2 ** 127, min_value=-(2 - 2 ** -23) * 2 ** 127)
 RANGE32 = dict(max_value=2 ** 31 - 1, min_value=-(2 ** 31) + 1)
 RANGE64 = dict(max_value=2 ** 63 - 1, min_value=-(2 ** 63) + 1)
 URANGE32 = dict(min_value=0, max_value=2 ** 32 - 1)
@@ -16,7 +17,7 @@ URANGE64 = dict(min_value=0, max_value=2 ** 64 - 1)
 
 SCALAR_MAPPINGS = {
     FieldDescriptor.TYPE_DOUBLE: st.floats(),
-    FieldDescriptor.TYPE_FLOAT: st.floats(),
+    FieldDescriptor.TYPE_FLOAT: st.floats(**SINGLEPRECISION),
     FieldDescriptor.TYPE_INT32: st.integers(**RANGE32),
     FieldDescriptor.TYPE_INT64: st.integers(**RANGE64),
     FieldDescriptor.TYPE_UINT32: st.integers(**URANGE32),

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,11 @@ setup(
     name='hypothesis-pb',
     packages=['hypothesis_protobuf'],
     platforms='any',
-    version='1.0.0',
+    version='1.0.1',
     description='Hypothesis extension to allow generating protobuf messages matching a schema.',
     author='H. Chase Stevens / Curata Inc.',
     author_email='chase@curata.com',
+    url='https://github.com/CurataEng/hypothesis-protobuf',
     license='MIT',
     install_requires=[
         'hypothesis>=3.4.2',

--- a/tests/unit/test_module_conversion.py
+++ b/tests/unit/test_module_conversion.py
@@ -22,6 +22,7 @@ def test_instant_message_example():
     assert isinstance(instant_message_example.sender.screen_name, basestring)
     assert isinstance(instant_message_example.recipient.screen_name, basestring)
     assert isinstance(instant_message_example.message, basestring)
+    assert isinstance(instant_message_example.metadata.latency, float)
 
 
 def test_overrides_respected():

--- a/tests/unit/test_schemas/im.proto
+++ b/tests/unit/test_schemas/im.proto
@@ -13,6 +13,10 @@ message User {
   string screen_name = 2;
 }
 
+message MetaData {
+  float latency = 1;
+}
+
 message InstantMessage {
   uint64 timestamp = 1;
   Client client = 2;
@@ -21,4 +25,5 @@ message InstantMessage {
   User recipient = 5;
   string message = 6;
   repeated bytes image_attachments = 7;
+  MetaData metadata = 8;
 }

--- a/tests/unit/test_schemas/im_pb2.py
+++ b/tests/unit/test_schemas/im_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='im.proto',
   package='im',
   syntax='proto3',
-  serialized_pb=_b('\n\x08im.proto\x12\x02im\"\'\n\x04User\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x13\n\x0bscreen_name\x18\x02 \x01(\t\"\xb5\x01\n\x0eInstantMessage\x12\x11\n\ttimestamp\x18\x01 \x01(\x04\x12\x1a\n\x06\x63lient\x18\x02 \x01(\x0e\x32\n.im.Client\x12\x11\n\tsender_ip\x18\x03 \x01(\x07\x12\x18\n\x06sender\x18\x04 \x01(\x0b\x32\x08.im.User\x12\x1b\n\trecipient\x18\x05 \x01(\x0b\x32\x08.im.User\x12\x0f\n\x07message\x18\x06 \x01(\t\x12\x19\n\x11image_attachments\x18\x07 \x03(\x0c*W\n\x06\x43lient\x12\x12\n\x0e\x43LIENT_UNKNOWN\x10\x00\x12\x15\n\x11\x43LIENT_NATIVE_APP\x10\x01\x12\x12\n\x0e\x43LIENT_WEB_APP\x10\x02\x12\x0e\n\nCLIENT_API\x10\x03\x62\x06proto3')
+  serialized_pb=_b('\n\x08im.proto\x12\x02im\"\'\n\x04User\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x13\n\x0bscreen_name\x18\x02 \x01(\t\"\x1b\n\x08MetaData\x12\x0f\n\x07latency\x18\x01 \x01(\x02\"\xd5\x01\n\x0eInstantMessage\x12\x11\n\ttimestamp\x18\x01 \x01(\x04\x12\x1a\n\x06\x63lient\x18\x02 \x01(\x0e\x32\n.im.Client\x12\x11\n\tsender_ip\x18\x03 \x01(\x07\x12\x18\n\x06sender\x18\x04 \x01(\x0b\x32\x08.im.User\x12\x1b\n\trecipient\x18\x05 \x01(\x0b\x32\x08.im.User\x12\x0f\n\x07message\x18\x06 \x01(\t\x12\x19\n\x11image_attachments\x18\x07 \x03(\x0c\x12\x1e\n\x08metadata\x18\x08 \x01(\x0b\x32\x0c.im.MetaData*W\n\x06\x43lient\x12\x12\n\x0e\x43LIENT_UNKNOWN\x10\x00\x12\x15\n\x11\x43LIENT_NATIVE_APP\x10\x01\x12\x12\n\x0e\x43LIENT_WEB_APP\x10\x02\x12\x0e\n\nCLIENT_API\x10\x03\x62\x06proto3')
 )
 
 _CLIENT = _descriptor.EnumDescriptor(
@@ -48,8 +48,8 @@ _CLIENT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=241,
-  serialized_end=328,
+  serialized_start=302,
+  serialized_end=389,
 )
 _sym_db.RegisterEnumDescriptor(_CLIENT)
 
@@ -96,6 +96,37 @@ _USER = _descriptor.Descriptor(
   ],
   serialized_start=16,
   serialized_end=55,
+)
+
+
+_METADATA = _descriptor.Descriptor(
+  name='MetaData',
+  full_name='im.MetaData',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='latency', full_name='im.MetaData.latency', index=0,
+      number=1, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=57,
+  serialized_end=84,
 )
 
 
@@ -155,6 +186,13 @@ _INSTANTMESSAGE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='metadata', full_name='im.InstantMessage.metadata', index=7,
+      number=8, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -167,14 +205,16 @@ _INSTANTMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=58,
-  serialized_end=239,
+  serialized_start=87,
+  serialized_end=300,
 )
 
 _INSTANTMESSAGE.fields_by_name['client'].enum_type = _CLIENT
 _INSTANTMESSAGE.fields_by_name['sender'].message_type = _USER
 _INSTANTMESSAGE.fields_by_name['recipient'].message_type = _USER
+_INSTANTMESSAGE.fields_by_name['metadata'].message_type = _METADATA
 DESCRIPTOR.message_types_by_name['User'] = _USER
+DESCRIPTOR.message_types_by_name['MetaData'] = _METADATA
 DESCRIPTOR.message_types_by_name['InstantMessage'] = _INSTANTMESSAGE
 DESCRIPTOR.enum_types_by_name['Client'] = _CLIENT
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -185,6 +225,13 @@ User = _reflection.GeneratedProtocolMessageType('User', (_message.Message,), dic
   # @@protoc_insertion_point(class_scope:im.User)
   ))
 _sym_db.RegisterMessage(User)
+
+MetaData = _reflection.GeneratedProtocolMessageType('MetaData', (_message.Message,), dict(
+  DESCRIPTOR = _METADATA,
+  __module__ = 'im_pb2'
+  # @@protoc_insertion_point(class_scope:im.MetaData)
+  ))
+_sym_db.RegisterMessage(MetaData)
 
 InstantMessage = _reflection.GeneratedProtocolMessageType('InstantMessage', (_message.Message,), dict(
   DESCRIPTOR = _INSTANTMESSAGE,


### PR DESCRIPTION
This PR fixes an issue in which values for protobuf `float` fields are generated which are outside IEEE 754 single-precision range. This manifests on some platforms (OSX) as a field packing error when attempting to serialize the message, e.g.:

```python
Message(float_field=2.1762075962280267e+298).SerializeToString()
---------------------------------------------------------------------------
OverflowError                             Traceback (most recent call last)
<ipython-input-6-528e3539fcdc> in <module>()
----> 1 Message(float_field=2.1762075962280267e+298).SerializeToString()
lib/python2.7/site-packages/google/protobuf/internal/python_message.pyc in SerializeToString(self)
   1034           'Message %s is missing required fields: %s' % (
   1035           self.DESCRIPTOR.full_name, ','.join(self.FindInitializationErrors())))
-> 1036     return self.SerializePartialToString()
   1037   cls.SerializeToString = SerializeToString
   1038 

lib/python2.7/site-packages/google/protobuf/internal/python_message.pyc in SerializePartialToString(self)
   1043   def SerializePartialToString(self):
   1044     out = BytesIO()
-> 1045     self._InternalSerialize(out.write)
   1046     return out.getvalue()
   1047   cls.SerializePartialToString = SerializePartialToString

lib/python2.7/site-packages/google/protobuf/internal/python_message.pyc in InternalSerialize(self, write_bytes)
   1049   def InternalSerialize(self, write_bytes):
   1050     for field_descriptor, field_value in self.ListFields():
-> 1051       field_descriptor._encoder(write_bytes, field_value)
   1052     for tag_bytes, value_bytes in self._unknown_fields:
   1053       write_bytes(tag_bytes)

lib/python2.7/site-packages/google/protobuf/internal/encoder.pyc in EncodeField(write, value)
    608         write(tag_bytes)
    609         try:
--> 610           write(local_struct_pack(format, value))
    611         except SystemError:
    612           EncodeNonFiniteOrRaise(write, value)

OverflowError: float too large to pack with f format
```

Because this is platform-dependent, the error cannot be reproduced on Linux - will need someone running OSX to verify the fix.