### PR TITLE
Fix width in floats strategy for pb float type

### DIFF
--- a/hypothesis_protobuf/module_conversion.py
+++ b/hypothesis_protobuf/module_conversion.py
@@ -9,7 +9,7 @@ from hypothesis import strategies as st
 from google.protobuf.internal.well_known_types import FieldDescriptor
 
 
-SINGLEPRECISION = dict(max_value=(2 - 2 ** -23) * 2 ** 127, min_value=-(2 - 2 ** -23) * 2 ** 127)
+SINGLEPRECISION = dict(max_value=(2 - 2 ** -23) * 2 ** 127, min_value=-(2 - 2 ** -23) * 2 ** 127, width=32)
 RANGE32 = dict(max_value=2 ** 31 - 1, min_value=-(2 ** 31) + 1)
 RANGE64 = dict(max_value=2 ** 63 - 1, min_value=-(2 ** 63) + 1)
 URANGE32 = dict(min_value=0, max_value=2 ** 32 - 1)


### PR DESCRIPTION
Protobuf float type is expected to be 32 bit wide,
hypothesis.strategies.floats() by default have width of 64 bits.